### PR TITLE
Git info versioning

### DIFF
--- a/ASCOM.DSLR/ASCOM.DSLR.csproj
+++ b/ASCOM.DSLR/ASCOM.DSLR.csproj
@@ -202,12 +202,12 @@
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>
-  <Import Project="..\packages\GitInfo.2.0.15\build\GitInfo.targets" Condition="Exists('..\packages\GitInfo.2.0.15\build\GitInfo.targets')" />
+  <Import Project="..\packages\GitInfo.2.0.11\build\GitInfo.targets" Condition="Exists('..\packages\GitInfo.2.0.11\build\GitInfo.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\GitInfo.2.0.15\build\GitInfo.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitInfo.2.0.15\build\GitInfo.targets'))" />
+    <Error Condition="!Exists('..\packages\GitInfo.2.0.11\build\GitInfo.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitInfo.2.0.11\build\GitInfo.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ASCOM.DSLR/ASCOM.DSLR.csproj
+++ b/ASCOM.DSLR/ASCOM.DSLR.csproj
@@ -36,6 +36,8 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>
@@ -144,6 +146,7 @@
     </None>
     <None Include="ASCOM.png" />
     <None Include="ASCOMDriverTemplate.snk" />
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -199,6 +202,13 @@
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>
+  <Import Project="..\packages\GitInfo.2.0.15\build\GitInfo.targets" Condition="Exists('..\packages\GitInfo.2.0.15\build\GitInfo.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\GitInfo.2.0.15\build\GitInfo.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitInfo.2.0.15\build\GitInfo.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/ASCOM.DSLR/Driver.cs
+++ b/ASCOM.DSLR/Driver.cs
@@ -53,6 +53,7 @@ namespace ASCOM.DSLR
     /// <summary>
     /// ASCOM Camera Driver for DSLR.
     /// </summary>
+    [ComVisible(true)]
     [Guid("37206417-4b15-49f0-ae46-a1e52aa20c2e")]
     [ClassInterface(ClassInterfaceType.None)]
     public partial class Camera : ICameraV2

--- a/ASCOM.DSLR/Properties/AssemblyInfo.cs
+++ b/ASCOM.DSLR/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Runtime.InteropServices;
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(true)]
+[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("47be61a3-fc7c-486d-a005-ce4943773d5b")]

--- a/ASCOM.DSLR/Properties/AssemblyInfo.cs
+++ b/ASCOM.DSLR/Properties/AssemblyInfo.cs
@@ -35,5 +35,12 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 //
 // TODO - Set your driver's version here
-[assembly: AssemblyVersion("6.2.*")]
-[assembly: AssemblyFileVersion("6.2.0.0")]
+
+[assembly: AssemblyVersion(ThisAssembly.Git.SemVer.Major + "." + ThisAssembly.Git.SemVer.Minor + "." + ThisAssembly.Git.SemVer.Patch)]
+[assembly: AssemblyFileVersion(ThisAssembly.Git.SemVer.Major + "." + ThisAssembly.Git.SemVer.Minor + "." + ThisAssembly.Git.SemVer.Patch)]
+[assembly: AssemblyInformationalVersion(
+    ThisAssembly.Git.SemVer.Major + "." +
+    ThisAssembly.Git.SemVer.Minor + "." +
+    ThisAssembly.Git.SemVer.Patch + "-" +
+    ThisAssembly.Git.Branch + "+" +
+    ThisAssembly.Git.Commit)]

--- a/ASCOM.DSLR/packages.config
+++ b/ASCOM.DSLR/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GitInfo" version="2.0.15" targetFramework="net46" developmentDependency="true" />
+  <package id="GitInfo" version="2.0.11" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/ASCOM.DSLR/packages.config
+++ b/ASCOM.DSLR/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="GitInfo" version="2.0.15" targetFramework="net46" developmentDependency="true" />
+</packages>


### PR DESCRIPTION
This pull request changes the versioning of the main assembly to be based on the GitInfo nuget package.

Basically the build looks at the git history for the most recent tag/branch of the form 

vX.Y.Z

and then adds the number of commits since that tag to the Z and that becomes the build number.

So if you create a tag 'v6.3.0' and you are now 32 commits after that tag then the build number will be '6.3.32.0'

Once this pull request is merged, just create a tag against a previous revision - say 'v6.3.0' to get correct build numbers. If no valid tag is found then the build numbers will be 0.1.XX where XX is the total number of git commits so far.

The point of this commit is to avoid the build number changing every time the code is rebuilt, which causes issues with the creation of COM objects. 