### PR TITLE
Fix stack overflow

### DIFF
--- a/ASCOM.DSLR/Classes/CanonSdkCamera.cs
+++ b/ASCOM.DSLR/Classes/CanonSdkCamera.cs
@@ -53,14 +53,19 @@ namespace ASCOM.DSLR.Classes
 
         public override CameraModel ScanCameras()
         {
+            ScanForCameras();
+            _mainCamera = CamList.First();
+            var cameraModel = GetCameraModel(_mainCamera.DeviceName);
+            return cameraModel;
+        }
+
+        private void ScanForCameras()
+        {
             CamList = APIHandler.GetCameraList();
             if (!CamList.Any())
             {
                 throw new NotConnectedException(ErrorMessages.NotConnected);
             }
-            _mainCamera = CamList.First();
-            var cameraModel = GetCameraModel(_mainCamera.DeviceName);
-            return cameraModel;
         }
 
 
@@ -118,7 +123,7 @@ namespace ASCOM.DSLR.Classes
 
         private void OpenSession()
         {
-            ScanCameras();
+            ScanForCameras();
             if (!MainCamera.SessionOpen)
             {
                 MainCamera.OpenSession();

--- a/EDSDKLib/API/Helper/ExceptionHandling.cs
+++ b/EDSDKLib/API/Helper/ExceptionHandling.cs
@@ -357,12 +357,9 @@ namespace EOSDigital.API
 
                 if (Severe) throw new SDKException(errorCode);
                 else
-                    NonSevereErrorHappenedEvent.BeginInvoke(sender, errorCode, (a) =>
-                    {
-                        var ar = a as AsyncResult;
-                        var invokedMethod = ar.AsyncDelegate as SDKExceptionHandler;
-                        invokedMethod.EndInvoke(a);
-                    }, null);
+                {
+                    Task.Run(() => NonSevereErrorHappenedEvent.Invoke(sender, errorCode));
+                }
             }
         }
 


### PR DESCRIPTION
There was a stack overflow in the canon code - 

CanonSdkCamera.ScanCameras calls BaseCamera.GetCameraModel
BaseCamera.GetCameraModel calls CameraModelDeletector.GetCameraModel
CameraModelDetector.GetCameraModel calls CanonSdkCamera.ConnectCamera
CanonSdkCamera.ConnectCamera calls OpenSession
OpenSession calls ScanCameras (and round and round it goes).

I think I have broken the loop at the correct place.

Also a fix for the problem where BeginInvoke fails on events that have more than one subscriber
