### PR TITLE
Gain handling

### DIFF
--- a/ASCOM.DSLR/Camera.cs
+++ b/ASCOM.DSLR/Camera.cs
@@ -363,8 +363,10 @@ namespace ASCOM.DSLR
         {
             get
             {
-                var iso = ApiContainer.DslrCamera.IsoValues.Select(i => "ISO" + i.ToString()).ToArray();
-                return new ArrayList(iso);
+                // ASCOM Camera drivers should implement either Gains or GainMin/GainMax, not both
+                // If Gains is implemented then the 'Gain' value is an index into the array returned by this property
+                // If GainMin/GainMax is implemented then the 'Gain' value is the numerical value of the gain. 
+                throw new PropertyNotImplementedException("The Gains property is not implemented");
             }
         }
 

--- a/ASCOM.DSLR/Classes/CanonSdkCamera.cs
+++ b/ASCOM.DSLR/Classes/CanonSdkCamera.cs
@@ -254,13 +254,12 @@ namespace ASCOM.DSLR.Classes
             var selectedIsoValue = ISOList.SingleOrDefault(v => v.DoubleValue == Iso && v.DoubleValue > 0);
             if (selectedIsoValue == null)
             {
-                var nearest = ISOValues.Values.Where(v => v.DoubleValue < short.MaxValue && v.DoubleValue > 0)
+                // EOS700D rejects ISO not in ISOList with BUSY error, assuming we need to stick to the values the camera advertises in its list
+                var nearest = ISOList.Where(v => v.DoubleValue < short.MaxValue && v.DoubleValue > 0)
                     .Select(v => new { value = v, difference = Math.Abs(v.DoubleValue - Iso) }).OrderBy(d => d.difference).First().value;
 
                 selectedIsoValue = nearest;
             }
-
-            var isoValue = ISOValues.GetValue((double)Iso);
 
             return selectedIsoValue;
         }

--- a/DSLR.Camera Setup.iss
+++ b/DSLR.Camera Setup.iss
@@ -22,7 +22,7 @@ Compression=lzma
 SolidCompression=yes
 ; Put there by Platform if Driver Installer Support selected
 WizardImageFile="C:\Program Files (x86)\ASCOM\Platform 6 Developer Components\Installer Generator\Resources\WizardImage.bmp"
-LicenseFile="C:\Program Files (x86)\ASCOM\Platform 6 Developer Components\Installer Generator\Resources\CreativeCommons.txt"
+LicenseFile="LICENSE"
 ; {cf}\ASCOM\Uninstall\Camera folder created by Platform, always
 UninstallFilesDir="{cf}\ASCOM\Uninstall\Camera\DSLR.Camera"
 
@@ -35,7 +35,7 @@ Name: "{cf}\ASCOM\Uninstall\Camera\DSLR.Camera"
 
 [Files]
 Source: "bin\ASCOM.DSLR.Camera.dll"; DestDir: "{app}"
-Source: "bin\ReadMe.htm"; DestDir: "{app}"; Flags: isreadme
+;Source: "bin\ReadMe.htm"; DestDir: "{app}"; Flags: isreadme
 Source: "bin\libraw.dll"; DestDir: "{app}"
 Source: "bin\EDSDK.dll"; DestDir: "{app}"
 Source: "bin\EDSDKLib.dll"; DestDir: "{app}"


### PR DESCRIPTION
Fix sending unsupported ISO to Canon camera resulting in error. Remove implementation of discrete gains from the ASCOM driver as having that and GainMin/GainMax is out-of-spec. 
Also put GPL3 license into the installer