### PR TITLE
First time use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ obj
 
 *.user
 .vs
+/*.exe

--- a/ASCOM.DSLR/Classes/BaseCamera.cs
+++ b/ASCOM.DSLR/Classes/BaseCamera.cs
@@ -84,12 +84,13 @@ namespace ASCOM.DSLR.Classes
 
         public CameraModel GetCameraModel(string cameraDescription)
         {
-            var cameraModel = _cameraModelsHistory.FirstOrDefault(c => c.Name == cameraDescription); //try get sensor params from history
+            var cameraModel = _cameraModelsHistory.FirstOrDefault(c => c?.Name == cameraDescription); //try get sensor params from history
             if (cameraModel == null)
             {
                 var cameraModelDetector = new CameraModelDetector(new ImageDataProcessor());
                 cameraModel = cameraModelDetector.GetCameraModel((IDslrCamera)this, StorePath ?? Path.GetTempPath());//make test shot to determine height/width
-                _cameraModelsHistory.Add(cameraModel);
+                if (cameraModel != null)
+                    _cameraModelsHistory.Add(cameraModel);
             }
 
             return cameraModel;

--- a/ASCOM.DSLR/Classes/BaseCamera.cs
+++ b/ASCOM.DSLR/Classes/BaseCamera.cs
@@ -89,6 +89,7 @@ namespace ASCOM.DSLR.Classes
             {
                 var cameraModelDetector = new CameraModelDetector(new ImageDataProcessor());
                 cameraModel = cameraModelDetector.GetCameraModel((IDslrCamera)this, StorePath ?? Path.GetTempPath());//make test shot to determine height/width
+                _cameraModelsHistory.Add(cameraModel);
             }
 
             return cameraModel;

--- a/ASCOM.DSLR/Classes/BaseCamera.cs
+++ b/ASCOM.DSLR/Classes/BaseCamera.cs
@@ -88,7 +88,7 @@ namespace ASCOM.DSLR.Classes
             if (cameraModel == null)
             {
                 var cameraModelDetector = new CameraModelDetector(new ImageDataProcessor());
-                cameraModel = cameraModelDetector.GetCameraModel((IDslrCamera)this, StorePath);//make test shot to determine height/width
+                cameraModel = cameraModelDetector.GetCameraModel((IDslrCamera)this, StorePath ?? Path.GetTempPath());//make test shot to determine height/width
             }
 
             return cameraModel;

--- a/ASCOM.DSLR/Driver.cs
+++ b/ASCOM.DSLR/Driver.cs
@@ -170,9 +170,10 @@ namespace ASCOM.DSLR
                 if (value)
                 {
                     connectedState = true;
+                    var previousModelHistory = CameraSettings.CameraModelsHistory.ToList();
                     ApiContainer.DslrCamera.ConnectCamera();
                     var model = ApiContainer.DslrCamera.CameraModel;
-                    if (model != null && !CameraSettings.CameraModelsHistory.Any(c => c.Name == model.Name))
+                    if (model != null && previousModelHistory.All(c => c.Name != model.Name))
                         WriteProfile(); // save the model info to avoid having to run test exposures next time
 
                 }

--- a/ASCOM.DSLR/Driver.cs
+++ b/ASCOM.DSLR/Driver.cs
@@ -171,6 +171,10 @@ namespace ASCOM.DSLR
                 {
                     connectedState = true;
                     ApiContainer.DslrCamera.ConnectCamera();
+                    var model = ApiContainer.DslrCamera.CameraModel;
+                    if (model != null && !CameraSettings.CameraModelsHistory.Any(c => c.Name == model.Name))
+                        WriteProfile(); // save the model info to avoid having to run test exposures next time
+
                 }
                 else
                 {

--- a/ASCOM.DSLR/Driver.cs
+++ b/ASCOM.DSLR/Driver.cs
@@ -174,7 +174,10 @@ namespace ASCOM.DSLR
                     ApiContainer.DslrCamera.ConnectCamera();
                     var model = ApiContainer.DslrCamera.CameraModel;
                     if (model != null && previousModelHistory.All(c => c.Name != model.Name))
+                    {
                         WriteProfile(); // save the model info to avoid having to run test exposures next time
+                        ApiContainer.DslrCamera.ConnectCamera(); // reconnect the camera because write profile disconnects it.
+                    }
 
                 }
                 else


### PR DESCRIPTION
Fix issues with first time use of the driver
* Make sure that once a trial shot is taken to identify the camera, the info gets saved rather than multiple trial shots being needed
* Ensure that the camera is left in a usable state after the initial trial shot